### PR TITLE
add in-repo add-on to prune the pods in-question.

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -17,7 +17,4 @@ var app = new EmberApp();
 // please specify an object with the list of modules as keys
 // along with the exports of each module as its value.
 
-var stew = require('broccoli-stew');
-module.exports = stew.rm(app.toTree(), 'app/modules/pod1', 'app/modules/pod2');
-
-// module.exports = app.toTree();
+module.exports = app.toTree();

--- a/lib/.jshintrc
+++ b/lib/.jshintrc
@@ -1,0 +1,4 @@
+{
+  "node": true,
+  "browser": false
+}

--- a/lib/remove/index.js
+++ b/lib/remove/index.js
@@ -1,0 +1,18 @@
+var stew = require('broccoli-stew');
+
+module.exports = {
+  name: 'remove',
+
+  isDevelopingAddon: function() {
+    return true;
+  },
+
+  postprocessTree: function(type, tree){
+    if (type === 'js' || type === 'template')   {
+      return stew.rm(tree, '*/modules/pod{1,2}/**/*');
+    } else {
+      return tree;
+    }
+  }
+
+};

--- a/lib/remove/package.json
+++ b/lib/remove/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "remove",
+  "keywords": [
+    "ember-addon"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -34,5 +34,13 @@
     "ember-disable-proxy-controllers": "^1.0.0",
     "ember-export-application-global": "^1.0.2",
     "broccoli-stew": "^0.3.1"
+  },
+  "ember-addon": {
+    "paths": [
+      "lib/remove"
+    ]
+  },
+  "dependencies": {
+    "broccoli-stew": "^0.3.1"
   }
 }


### PR DESCRIPTION
module.exports = app.toTree() is to late, since everything is already built

instead the Addon.prototype.postprocessTree should be used.

Please note: this also depends on -> https://github.com/ember-cli/ember-cli/issues/4260
